### PR TITLE
date on notes

### DIFF
--- a/TicketSystem.py
+++ b/TicketSystem.py
@@ -35,7 +35,7 @@ class Ticket:
         self.status = new_status
 
     def add_note(self, note):
-        note_entry = {'note': note, 'timestamp': datetime.now().strftime('%m-d-%Y %H:%M:%S')}
+        note_entry = {'note': note, 'timestamp': datetime.now().strftime('%m-%d-%Y %H:%M:%S')}
         self.notes.append(note_entry)
 
     def close(self):

--- a/TicketSystem.spec
+++ b/TicketSystem.spec
@@ -1,0 +1,37 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+
+a = Analysis(
+    ['ticketsystem.py'],
+    pathex=[],
+    binaries=[],
+    datas=[],
+    hiddenimports=[],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    noarchive=False,
+)
+pyz = PYZ(a.pure)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.datas,
+    [],
+    name='ticketsystem',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    runtime_tmpdir=None,
+    console=True,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+)


### PR DESCRIPTION
Fixed the dates on the notes added to each ticket. Before, it would add the note and lets say it was march 3rd, it might say 3-d-2024. It was saying d instead of the day. Simple typo. Changed the d to the %d variable and all set.